### PR TITLE
refactor: use fromNumber instead of constructor

### DIFF
--- a/src/contract/tok_ctrt_no_split.js
+++ b/src/contract/tok_ctrt_no_split.js
@@ -153,7 +153,7 @@ export class TokCtrtWithoutSplit extends ctrt.BaseTokCtrt {
   async getTokBal(addr) {
     const resp = await this.chain.api.ctrt.getTokBal(addr, this.tokId.data);
     const unit = await this.getUnit();
-    return new md.Token(new bn.BigNumber(resp.balance), unit);
+    return md.Token.fromNumber(resp.balance, unit);
   }
 
   /**


### PR DESCRIPTION
## What Does This PR Do
use fromNumber instead of constructor.
## How Is The Changes Tested
tested manually.