### PR TITLE
refactor: avoid using built-in BigInt

### DIFF
--- a/src/contract/pay_chan_ctrt.js
+++ b/src/contract/pay_chan_ctrt.js
@@ -566,7 +566,7 @@ export class PayChanCtrt extends ctrt.Ctrt {
     const msg = Buffer.concat([
       bp.packUInt16(chanIdBytes.length),
       chanIdBytes,
-      bp.packUInt64(bn.toBigInt(rawAmount)),
+      bp.packUInt64(rawAmount),
     ]);
 
     return msg;

--- a/src/data_entry.js
+++ b/src/data_entry.js
@@ -164,7 +164,7 @@ class Long extends DataEntry {
    * @returns {Buffer} The bytes representation of this data entry.
    */
   get bytes() {
-    return bp.packUInt64(this.data.bigInt);
+    return bp.packUInt64(this.data.data);
   }
 
   /**

--- a/src/model.js
+++ b/src/model.js
@@ -827,14 +827,6 @@ export class Long extends Model {
   }
 
   /**
-   * bigInt returns the containing data in JavaScript built-in BigInt.
-   * @returns {BigInt}
-   */
-  get bigInt() {
-    return bn.toBigInt(this.data);
-  }
-
-  /**
    * validate validates the instance.
    */
   validate() {

--- a/src/tx_req.js
+++ b/src/tx_req.js
@@ -95,9 +95,9 @@ export class PaymentTxReq extends TxReq {
     const cls = this.constructor;
     return Buffer.concat([
       cls.TX_TYPE.serialize(),
-      bp.packUInt64(this.timestamp.bigInt),
-      bp.packUInt64(this.amount.bigInt),
-      bp.packUInt64(this.fee.bigInt),
+      bp.packUInt64(this.timestamp.data),
+      bp.packUInt64(this.amount.data),
+      bp.packUInt64(this.fee.data),
       bp.packUInt16(cls.FEE_SCALE),
       this.recipient.bytes,
       bp.packUInt16(this.attachment.data.length),
@@ -162,9 +162,9 @@ export class RegCtrtTxReq extends TxReq {
       dataStack,
       bp.packUInt16(this.description.data.length),
       this.description.bytes,
-      bp.packUInt64(this.fee.bigInt),
+      bp.packUInt64(this.fee.data),
       bp.packUInt16(cls.FEE_SCALE),
-      bp.packUInt64(this.timestamp.bigInt),
+      bp.packUInt64(this.timestamp.data),
     ]);
   }
 
@@ -226,9 +226,9 @@ export class ExecCtrtFuncTxReq extends TxReq {
       dataStack,
       bp.packUInt16(this.attachment.data.length),
       this.attachment.bytes,
-      bp.packUInt64(this.fee.bigInt),
+      bp.packUInt64(this.fee.data),
       bp.packUInt16(cls.FEE_SCALE),
-      bp.packUInt64(this.timestamp.bigInt),
+      bp.packUInt64(this.timestamp.data),
     ]);
   }
 
@@ -281,10 +281,10 @@ export class LeaseTxReq extends TxReq {
     return Buffer.concat([
       cls.TX_TYPE.serialize(),
       this.supernodeAddr.bytes,
-      bp.packUInt64(this.amount.bigInt),
-      bp.packUInt64(this.fee.bigInt),
+      bp.packUInt64(this.amount.data),
+      bp.packUInt64(this.fee.data),
       bp.packUInt16(cls.FEE_SCALE),
-      bp.packUInt64(this.timestamp.bigInt),
+      bp.packUInt64(this.timestamp.data),
     ]);
   }
 
@@ -332,9 +332,9 @@ export class LeaseCancelReq extends TxReq {
 
     return Buffer.concat([
       cls.TX_TYPE.serialize(),
-      bp.packUInt64(this.fee.bigInt),
+      bp.packUInt64(this.fee.data),
       bp.packUInt16(cls.FEE_SCALE),
-      bp.packUInt64(this.timestamp.bigInt),
+      bp.packUInt64(this.timestamp.data),
       this.leasingTxId.bytes,
     ]);
   }

--- a/src/utils/big_number.js
+++ b/src/utils/big_number.js
@@ -7,12 +7,3 @@
 
 import jsBNPkg from 'bignumber.js';
 export const { BigNumber } = jsBNPkg;
-
-/**
- * toBigInt converts BigNumber to JS built-in BigInt
- * @param {BigNumber} bn - The BigNumber instance.
- * @returns {BigInt} The BigInt instance.
- */
-export function toBigInt(bn) {
-  return BigInt('0x' + bn.toString(16));
-}

--- a/src/utils/bytes_packer.js
+++ b/src/utils/bytes_packer.js
@@ -7,6 +7,9 @@
 
 import { Buffer } from 'buffer';
 
+import jsBNPkg from 'bignumber.js';
+export const { BigNumber } = jsBNPkg;
+
 /**
  * packUInt8 packs the given integer into 1 byte
  * @param {number} val - The value to pack.
@@ -53,13 +56,21 @@ export function packUInt32(val) {
 
 /**
  * packUInt64 packs the given integer into 8 bytes in Big Endian order.
- * @param {BigInt} val - The value to pack.
+ * @param {BigNumber} val - The value to pack.
  * @returns {Buffer} The packing result.
  */
 export function packUInt64(val) {
-  const buf = Buffer.alloc(8);
-  buf.writeBigUInt64BE(val);
-  return buf;
+  let s = val.toString(16);
+  if (s.length < 16) {
+    let diff = 16 - s.length;
+    let prefix = '';
+    while (diff--) {
+      prefix = prefix + '0';
+    }
+    s = prefix + s;
+  }
+
+  return Buffer.from(s, 'hex');
 }
 
 /**
@@ -101,10 +112,11 @@ export function unpackUInt32(buf) {
 /**
  * unpackUInt64 unpacks the given 8-byte Buffer to an integer in Big Endian order.
  * @param {Buffer} buf - The 8-byte buffer to unpack.
- * @returns {BigInt} The unpacking result.
+ * @returns {BigNumber} The unpacking result.
  */
 export function unpackUInt64(buf) {
-  return buf.readUInt64BE(0);
+  const s = buf.toString('hex');
+  return new BigNumber(s, 16);
 }
 
 /**


### PR DESCRIPTION
## What Does This PR Do
Use string as the intermediate media for the conversion between `BigNumber` & `Buffer` so as to remove the usage of `BigInt` to be compatible with platforms that do not support `BigInt`.

## How Is The Changes Tested
Functional tests passed locally.