### PR TITLE
refactor: import crypto-js submodule

### DIFF
--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -1,0 +1,38 @@
+/**
+ * modelSpec tests module model.
+ * @module modelSpec
+ */
+
+'use strict';
+
+import * as jv from '../src/index.js';
+
+describe('Test class Seed', function () {
+    describe('Test method encrypt', function () {
+        it('should properly encrypt', function () {
+            const key = 'abc';
+            const rounds = 5000;
+
+            const seed = new jv.Seed(this.SEED);  
+            const enc = seed.encrypt(key, rounds);
+
+            const dec = enc.decrypt(key, rounds);
+            expect(dec.data).toEqual(seed.data);
+        });
+    });
+});
+
+describe('Test class EncryptedSeed', function () {
+    describe('Test method decrypt', function () {
+        it('should properly decrypt', function () {
+            const key = 'abc';
+            const rounds = 5000;
+
+            const seed = new jv.Seed(this.SEED);  
+            const enc = seed.encrypt(key, rounds);
+
+            const dec = enc.decrypt(key, rounds);
+            expect(dec.data).toEqual(seed.data);
+        });
+    });
+});

--- a/src/model.js
+++ b/src/model.js
@@ -12,6 +12,7 @@ import * as bn from './utils/big_number.js';
 import * as bp from './utils/bytes_packer.js';
 import * as hs from './utils/hashes.js';
 import * as curve from './utils/curve_25519.js';
+import * as crypto from './utils/crypto.js';
 import { WORDS_SET } from './words.js';
 
 /** Model is the base class for data models */
@@ -239,7 +240,7 @@ export class Seed extends Str {
       throw new Error('Password is required');
     }
     password = this.constructor.strengthenPassword(password, encryptionRounds);
-    return new EncryptedSeed(hs.aesEncrypt(this.data, password));
+    return new EncryptedSeed(crypto.aesEncrypt(this.data, password));
   }
 
   /**
@@ -276,7 +277,7 @@ export class EncryptedSeed extends Str {
       throw new Error('Password is required');
     }
     password = Seed.strengthenPassword(password, encryptionRounds);
-    return new Seed(hs.aesDecrypt(this.data, password));
+    return new Seed(crypto.aesDecrypt(this.data, password));
   }
 }
 

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -1,0 +1,29 @@
+/**
+ * module utils/crypto provides functionalities for cryptograhphy.
+ * @module utils/crypto
+ */
+
+'use strict';
+
+import encUtf8 from "crypto-js/enc-utf8.js"
+import AES from "crypto-js/aes.js";
+
+/**
+ * aesEncrypt encrypts the given data in AES.
+ * @param {string} data - The data to encrypt.
+ * @param {string} key - The key used to encrypt data.
+ * @returns {string} The encryption result
+*/
+export function aesEncrypt(data, key) {
+  return AES.encrypt(data, key).toString();
+}
+  
+/**
+ * aesDecrypt decrypts the given data encrypted by AES.
+ * @param {string} data - The data to decrypt.
+ * @param {string} key - The key used to decrypt data.
+ * @returns {string} The decryption result.
+ */
+export function aesDecrypt(data, key) {
+  return AES.decrypt(data, key).toString(encUtf8);
+}

--- a/src/utils/hashes.js
+++ b/src/utils/hashes.js
@@ -10,7 +10,6 @@ import blake from 'blakejs';
 const { blake2b } = blake;
 import keccak256 from 'keccak256';
 import sha256 from 'js-sha256';
-import CryptoJS from 'crypto-js';
 
 /**
  * sha256Hash hashes the given data in SHA256
@@ -37,24 +36,4 @@ export function keccak256Hash(data) {
  */
 export function blake2b32Hash(data) {
   return Buffer.from(blake2b(data, null, 32), 'latin1');
-}
-
-/**
- * aesEncrypt encrypts the given data in AES.
- * @param {string} data - The data to encrypt.
- * @param {string} key - The key used to encrypt data.
- * @returns {string} The encryption result
- */
-export function aesEncrypt(data, key) {
-  return CryptoJS.AES.encrypt(data, key).toString();
-}
-
-/**
- * aesDecrypt decrypts the given data encrypted by AES.
- * @param {string} data - The data to decrypt.
- * @param {string} key - The key used to decrypt data.
- * @returns {string} The decryption result.
- */
-export function aesDecrypt(data, key) {
-  return CryptoJS.AES.decrypt(data, key).toString(CryptoJS.enc.Utf8);
 }


### PR DESCRIPTION
## What Does This PR Do
Move function `aesEncrypt` & `aesDecrypt` to module `crypto.js` and import submodules from `crypto-js` so as to ensure
- compatibility when using in frontend cases
- smaller import size

## How Is The Changes Tested
Test cases passed locally.

