### PR TITLE
fix: fix getCtrtId

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -729,7 +729,7 @@ export class TokenID extends FixedSizedB58Str {
    * @returns {CtrtID} The contract ID.
    */
   getCtrtId() {
-    const b = bs58.decode(this.data);
+    const b = this.bytes;
     const rawCtrtId = b.slice(
       1,
       b.length - CtrtMeta.TOKEN_IDX_BYTES_LEN - CtrtMeta.CHECKSUM_LEN


### PR DESCRIPTION
## What Does This PR Do
Fix the bug where it throws "list argument must be an array of Buffers" when calling the method "getCtrtid" in the browser environment.

## How Is The Changes Tested
Tested locally.